### PR TITLE
Call a hook after switching keys

### DIFF
--- a/cmd/skm/actions.go
+++ b/cmd/skm/actions.go
@@ -157,6 +157,8 @@ func use(c *cli.Context) error {
 
 	// Set key with related alias as default used key
 	skm.CreateLink(alias)
+	// Run a potential hook
+	skm.RunHook(alias)
 	color.Green("Now using SSH key: [%s]", alias)
 	return nil
 }

--- a/utils.go
+++ b/utils.go
@@ -29,6 +29,9 @@ const (
 	PrivateKey = "id_rsa"
 	// DefaultKey is the default alias name of SSH key
 	DefaultKey = "default"
+
+	// HookName is the name of a hook that is called when present after using a key
+	HookName = "hook"
 )
 
 var (
@@ -103,6 +106,14 @@ func DeleteKey(alias string, key *SSHKey, forTest ...bool) {
 			color.Green("%sSSH key [%s] deleted!", CheckSymbol, alias)
 		} else {
 			color.Red("%sFailed to delete SSH key [%s]!", CrossSymbol, alias)
+		}
+	}
+}
+
+func RunHook(alias string) {
+	if info, err := os.Stat(filepath.Join(StorePath, alias, HookName)); !os.IsNotExist(err) {
+		if info.Mode() & 0111 != 0 {
+			Execute("", filepath.Join(StorePath, alias, HookName), alias)
 		}
 	}
 }


### PR DESCRIPTION
Hi,

I switch between work key and private key. Besides the keys some other stuff ( mainly the git config in terms of mail ) has to be changed then as well.

I see the following possible approaches:

1. Adjusting the git config and thus becoming a git configuration manager
2. Having a list of commands in a config file to be run after/before key change
3. Having some kind of a hook ( an executable with predefined name lying side-by-side with the key )

I decided to do number three and do a pull request, as this probable has the least impact on the work flow.

Kind regards,
Sascha