### PR TITLE
Add support for ED25519 keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ SKM will create SSH key store at ```$HOME/.skm``` and put all the SSH keys in it
 __NOTE:__ If you already have id_rsa & id_rsa.pub key pairs in ```$HOME/.ssh```, SKM will move them to ```$HOME/.skm/default```
 
 ### Create a new SSH key
-__NOTE:__ Currently __ONLY__ RSA key type is supported!
+__NOTE:__ Currently __ONLY__ RSA and ED25519 keys are supported!
 
 ```bash
 skm create prod -C "abc@abc.com"

--- a/cmd/skm/actions_test.go
+++ b/cmd/skm/actions_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/TimothyYe/skm"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+var random *rand.Rand
+
+func init() {
+	random = rand.New(rand.NewSource(time.Now().Unix()))
+}
+
+func TestInitAction(t *testing.T) {
+	testcases := []struct {
+		code  string
+		info  string
+		err   bool
+		check func(t *testing.T, env *skm.Environment)
+		setup func(t *testing.T, env *skm.Environment)
+	}{
+		{
+			code: "no-preexisting-key",
+			info: "If the .ssh folder is empty, then no default profile should be created",
+			err:  false,
+			check: func(t *testing.T, env *skm.Environment) {
+				assertEmptyDir(t, env.StorePath, "no-preexisting-key")
+			},
+		},
+		{
+			code: "rsa-key",
+			info: "If the .ssh folder contains an RSA key-pair, it should be copied into the default profile",
+			setup: func(t *testing.T, env *skm.Environment) {
+				os.RemoveAll(env.StorePath)
+				writeFile(t, filepath.Join(env.SSHPath, "id_rsa"), []byte("private"))
+				writeFile(t, filepath.Join(env.SSHPath, "id_rsa.pub"), []byte("public"))
+			},
+			err: false,
+			check: func(t *testing.T, env *skm.Environment) {
+				assertFileExists(t, filepath.Join(env.StorePath, "default", "id_rsa"), "rsa")
+				assertFileExists(t, filepath.Join(env.StorePath, "default", "id_rsa.pub"), "rsa")
+			},
+		},
+		{
+			code: "ed25519-key",
+			info: "If the .ssh folder contains an ED25519 key-pair, it should be copied into the default profile",
+			setup: func(t *testing.T, env *skm.Environment) {
+				os.RemoveAll(env.StorePath)
+				writeFile(t, filepath.Join(env.SSHPath, "id_ed25519"), []byte("private"))
+				writeFile(t, filepath.Join(env.SSHPath, "id_ed25519.pub"), []byte("public"))
+			},
+			err: false,
+			check: func(t *testing.T, env *skm.Environment) {
+				assertFileExists(t, filepath.Join(env.StorePath, "default", "id_ed25519"), "ed25519")
+				assertFileExists(t, filepath.Join(env.StorePath, "default", "id_ed25519.pub"), "ed25519")
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		env := setupEnvironment(t)
+		flags := flag.NewFlagSet("", flag.ContinueOnError)
+		flags.String("ssh-path", env.SSHPath, "")
+		flags.String("store-path", env.StorePath, "")
+		if testcase.setup != nil {
+			testcase.setup(t, env)
+		}
+		if !t.Failed() {
+			c := cli.NewContext(nil, flags, nil)
+			err := initialize(c)
+			if err == nil && testcase.err {
+				t.Errorf("[%s] should have returned an error", testcase.code)
+			}
+			if err != nil && !testcase.err {
+				t.Errorf("[%s] produced an unexpected error: %s", testcase.code, err.Error())
+			}
+			if testcase.check != nil {
+				testcase.check(t, env)
+			}
+		}
+		tearDownEnvironment(t, env)
+		if t.Failed() {
+			break
+		}
+	}
+}
+
+func setupEnvironment(t *testing.T) *skm.Environment {
+	rootFolder := filepath.Join(os.TempDir(), fmt.Sprintf("skm-testdir-%d", random.Int()))
+	storePath := filepath.Join(rootFolder, ".skm")
+	sshPath := filepath.Join(rootFolder, ".ssh")
+	if err := os.MkdirAll(storePath, 0700); err != nil {
+		t.Errorf("Failed to create store path: %s", err.Error())
+		return nil
+	}
+	if err := os.MkdirAll(sshPath, 0700); err != nil {
+		t.Errorf("Failed to create ssh path: %s", err.Error())
+		return nil
+	}
+	return &skm.Environment{
+		StorePath: storePath,
+		SSHPath:   sshPath,
+	}
+}
+
+func tearDownEnvironment(t *testing.T, env *skm.Environment) {
+	rootFolder := filepath.Dir(env.StorePath)
+	os.RemoveAll(rootFolder)
+}
+
+func assertFileExists(t *testing.T, path string, code string) {
+	_, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("[%s] Failed to assert file existance: %s (err: %v)", code, path, err)
+	}
+}
+
+func assertEmptyDir(t *testing.T, path string, code string) {
+	empty, err := skm.IsEmpty(path)
+	if err != nil || !empty {
+		t.Fatalf("[%s] Failed to assert empty directory %s: %v", code, path, err)
+	}
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	if t.Failed() {
+		return
+	}
+	if err := ioutil.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("Failed to write %s: %s", path, err.Error())
+	}
+}

--- a/cmd/skm/cli_test.go
+++ b/cmd/skm/cli_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"os"
 	"os/exec"
+	"strconv"
 	"testing"
 )
 
 func TestUsage(t *testing.T) {
+	assertE2ETest(t)
 	prepareTest(t)
 	defer os.Remove("$GOPATH/bin/skm")
 	cmd := exec.Command("skm", "-h")
@@ -17,6 +19,7 @@ func TestUsage(t *testing.T) {
 }
 
 func TestInvalidArgs(t *testing.T) {
+	assertE2ETest(t)
 	prepareTest(t)
 	expectString := "No help topic for 'hogehoge'\n"
 	defer os.Remove("$GOPATH/bin/skm")
@@ -38,4 +41,11 @@ func runCmd(t *testing.T, cmd string, args ...string) []byte {
 		t.Fatalf("Expected %v, but %v: %v", nil, err, string(b))
 	}
 	return b
+}
+
+func assertE2ETest(t *testing.T) {
+	active, _ := strconv.ParseBool(os.Getenv("GOTEST_RUN_E2E"))
+	if !active {
+		t.Skip()
+	}
 }

--- a/cmd/skm/commands.go
+++ b/cmd/skm/commands.go
@@ -20,6 +20,7 @@ func initCommands() []cli.Command {
 			Flags: []cli.Flag{
 				cli.StringFlag{Name: "b", Usage: "bits"},
 				cli.StringFlag{Name: "C", Usage: "comment"},
+				cli.StringFlag{Name: "t", Usage: "type"},
 			},
 		},
 		{

--- a/cmd/skm/main.go
+++ b/cmd/skm/main.go
@@ -1,22 +1,51 @@
 package main
 
 import (
+	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/TimothyYe/skm"
 
 	cli "gopkg.in/urfave/cli.v1"
 )
 
+var defaultStorePath = filepath.Join(os.Getenv("HOME"), ".skm")
+var defaultSSHPath = filepath.Join(os.Getenv("HOME"), ".ssh")
+
 func main() {
 	parseArgs()
 
 	app := cli.NewApp()
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "store-path",
+			Value: defaultStorePath,
+			Usage: "Path where SKM should store its profiles",
+		},
+		cli.StringFlag{
+			Name:  "ssh-path",
+			Value: defaultSSHPath,
+			Usage: "Path to a .ssh folder",
+		},
+	}
 	app.Name = skm.Name
 	app.Usage = skm.Usage
 	app.Version = Version
 	app.Commands = initCommands()
 	app.Run(os.Args)
+}
+
+func mustGetEnvironment(ctx *cli.Context) *skm.Environment {
+	storePath := ctx.GlobalString("store-path")
+	sshPath := ctx.GlobalString("ssh-path")
+	if storePath == "" || sshPath == "" {
+		log.Fatalf("store-path (%v) and ssh-path (%v) have to be set!", storePath, sshPath)
+	}
+	return &skm.Environment{
+		StorePath: storePath,
+		SSHPath:   sshPath,
+	}
 }
 
 // ParseArgs parses input arguments and displays the program logo

--- a/keytypes.go
+++ b/keytypes.go
@@ -1,0 +1,25 @@
+package skm
+
+// KeyTypeRegistry is used to store all the supported key types.
+type KeyTypeRegistry map[string]KeyType
+
+// GetByFilename returns a key type object given the name of the private key's
+// file. If no matching key type could be found, then the second return value
+// is false.
+func (r KeyTypeRegistry) GetByFilename(name string) (KeyType, bool) {
+	for _, kt := range r {
+		if name == kt.KeyBaseName {
+			return kt, true
+		}
+	}
+	return KeyType{}, false
+}
+
+// SupportedKeyTypes contains all key types supported by skm.
+var SupportedKeyTypes KeyTypeRegistry
+
+func init() {
+	SupportedKeyTypes = KeyTypeRegistry{}
+	SupportedKeyTypes["rsa"] = KeyType{Name: "rsa", SupportsVariableBitsize: true, KeyBaseName: "id_rsa"}
+	SupportedKeyTypes["ed25519"] = KeyType{Name: "ed25519", SupportsVariableBitsize: true, KeyBaseName: "id_ed25519"}
+}

--- a/keytypes_test.go
+++ b/keytypes_test.go
@@ -1,0 +1,36 @@
+package skm
+
+import "testing"
+
+func TestKeyTypeRegistry(t *testing.T) {
+	testcases := []struct {
+		name  string
+		input string
+		found bool
+	}{
+		{
+			name:  "rsa",
+			input: "id_rsa",
+			found: true,
+		},
+		{
+			name:  "ed25519",
+			input: "id_ed25519",
+			found: true,
+		},
+		{
+			name:  "",
+			input: "unsupported",
+			found: false,
+		},
+	}
+	for _, testcase := range testcases {
+		kt, found := SupportedKeyTypes.GetByFilename(testcase.input)
+		if found != testcase.found {
+			t.Fatalf("%s should have returned %v, but got %v instead", testcase.input, testcase.found, found)
+		}
+		if kt.Name != testcase.name {
+			t.Fatalf("%s should have returned %v, but got %v instead", testcase.input, testcase.name, kt.Name)
+		}
+	}
+}

--- a/models.go
+++ b/models.go
@@ -1,8 +1,36 @@
 package skm
 
+import "fmt"
+
+// Environment abstracts away things like the path the .skm and .ssh folder
+// which allows us to simulate them for testing.
+type Environment struct {
+	StorePath string
+	SSHPath   string
+}
+
 // SSHKey struct includes both private/public keys & isDefault flag
 type SSHKey struct {
 	PublicKey  string
 	PrivateKey string
 	IsDefault  bool
+	Type       *KeyType
+}
+
+// KeyType abstracts configurations for various SSH key types like RSA and
+// ED25519
+type KeyType struct {
+	Name                    string
+	KeyBaseName             string
+	SupportsVariableBitsize bool
+}
+
+// PrivateKey returns the filename used by a keytype for the private component.
+func (kt KeyType) PrivateKey() string {
+	return kt.KeyBaseName
+}
+
+// PrivateKey returns the filename used by a keytype for the public component.
+func (kt KeyType) PublicKey() string {
+	return fmt.Sprintf("%s.pub", kt.KeyBaseName)
 }


### PR DESCRIPTION
This also includes an abstraction layer for environment in order to better test .skm and .ssh folders without putting the ones stored in the user's $HOME at risk.

Additionally, I've put all the E2E tests behind the `GOTEST_RUN_E2E` environment variable.