### PR TITLE
Fix: get home path and using rel path to create symlink

### DIFF
--- a/cmd/skm/main.go
+++ b/cmd/skm/main.go
@@ -11,9 +11,9 @@ import (
 
 	cli "gopkg.in/urfave/cli.v1"
 )
-
-var defaultStorePath = filepath.Join(os.Getenv("HOME"), ".skm")
-var defaultSSHPath = filepath.Join(os.Getenv("HOME"), ".ssh")
+var home,_ = os.UserHomeDir();
+var defaultStorePath = filepath.Join(home, ".skm")
+var defaultSSHPath = filepath.Join(home, ".ssh")
 
 func init() {
 	// initialize the store path

--- a/utils.go
+++ b/utils.go
@@ -176,14 +176,18 @@ func CreateLink(alias string, keyMap map[string]*SSHKey, env *Environment) {
 	if !found {
 		return
 	}
+	relStorePath, err := filepath.Rel(env.SSHPath, env.StorePath)
+	if err != nil {
+		fmt.Println("Failed to find rel store path")
+	}
 	//Create symlink for private key
-	if err := os.Symlink(filepath.Join(env.StorePath, alias, key.Type.PrivateKey()), filepath.Join(env.SSHPath, key.Type.PrivateKey())); err != nil {
+	if err := os.Symlink(filepath.Join(relStorePath, alias, key.Type.PrivateKey()), filepath.Join(env.SSHPath, key.Type.PrivateKey())); err != nil {
 		fmt.Println("Failed to create symble link for private key")
 		return
 	}
 
 	//Create symlink for public key
-	if err := os.Symlink(filepath.Join(env.StorePath, alias, key.Type.PublicKey()), filepath.Join(env.SSHPath, key.Type.PublicKey())); err != nil {
+	if err := os.Symlink(filepath.Join(relStorePath, alias, key.Type.PublicKey()), filepath.Join(env.SSHPath, key.Type.PublicKey())); err != nil {
 		fmt.Println("Failed to create symble link for private key")
 		return
 	}


### PR DESCRIPTION
Using `os.UserHomeDir()` to get home path correctly on Windows.
Using rel path when creating symlink to avoid Windows symlink issue.