### PR TITLE
handle the case that store path is symbolic link dir

### DIFF
--- a/cmd/skm/main.go
+++ b/cmd/skm/main.go
@@ -21,6 +21,9 @@ func init() {
 	if envStorePath := os.Getenv("SKM_STORE_PATH"); envStorePath != "" {
 		defaultStorePath = envStorePath
 	}
+	if d, err := os.Readlink(defaultStorePath); err == nil {
+		defaultStorePath = d
+	}
 }
 
 func main() {


### PR DESCRIPTION
I put my keys on iCloud and create a symbolic link directory(~/.skm) to point to it, then skm can't find keys. I knew I can set `SKM_STORE_PATH` to specify the real directory rather than a link, but it would be cleaner without this config item I think. 
