### PR TITLE
Improve: Add partial match for use command

### DIFF
--- a/internal/actions/use.go
+++ b/internal/actions/use.go
@@ -1,11 +1,13 @@
 package actions
 
 import (
+	"sort"
+	"strings"
+
 	"github.com/TimothyYe/skm/internal/utils"
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
 	"gopkg.in/urfave/cli.v1"
-	"sort"
 )
 
 func Use(c *cli.Context) error {
@@ -46,11 +48,25 @@ func Use(c *cli.Context) error {
 		alias = result
 	}
 
+	// complete match key
 	_, ok := keyMap[alias]
 
 	if !ok {
-		color.Red("Key alias: %s doesn't exist!", alias)
-		return nil
+		// partial match key
+		canPartialMatch := false
+
+		for k, _ := range keyMap {
+			if strings.Index(k, alias) >= 0 {
+				alias = k
+				canPartialMatch = true
+				break
+			}
+		}
+
+		if !canPartialMatch {
+			color.Red("Key alias: %s doesn't exist!", alias)
+			return nil
+		}
 	}
 
 	// Set key with related alias as default used key


### PR DESCRIPTION
- If the complete match does not work, then add a partial match logic when the 'use' command is used.