### PR TITLE
feat: allow different type keys to coexist

### DIFF
--- a/cmd/skm/main.go
+++ b/cmd/skm/main.go
@@ -44,6 +44,11 @@ func main() {
 			Value: "",
 			Usage: "Path to the restic binary",
 		},
+		cli.BoolFlag{
+			Name:   "keep-type-keys",
+			Usage:  "Keep different ssh type keys",
+			EnvVar: "SKM_KEEP_TYPE_KEYS",
+		},
 	}
 	app.Name = utils.Name
 	app.Usage = utils.Usage

--- a/cmd/skm/main.go
+++ b/cmd/skm/main.go
@@ -45,9 +45,9 @@ func main() {
 			Usage: "Path to the restic binary",
 		},
 		cli.BoolFlag{
-			Name:   "keep-type-keys",
-			Usage:  "Keep different ssh type keys",
-			EnvVar: "SKM_KEEP_TYPE_KEYS",
+			Name:   "multi-key-types",
+			Usage:  "Support for multi key types",
+			EnvVar: "SKM_MULTI_KEY_TYPES",
 		},
 	}
 	app.Name = utils.Name

--- a/internal/actions/restore.go
+++ b/internal/actions/restore.go
@@ -60,7 +60,7 @@ func Restore(c *cli.Context) error {
 	}
 
 	// Clear all keys
-	utils.ClearKey(env)
+	utils.ClearKey(env, "")
 	err = os.Mkdir(env.StorePath, 0755)
 	if err != nil {
 		color.Red("%sFailed to initialize SSH key store!", utils.CrossSymbol)

--- a/internal/models/key_type.go
+++ b/internal/models/key_type.go
@@ -5,9 +5,10 @@ import "fmt"
 // Environment abstracts away things like the path the .skm and .ssh folder
 // which allows us to simulate them for testing.
 type Environment struct {
-	StorePath  string
-	SSHPath    string
-	ResticPath string
+	StorePath    string
+	SSHPath      string
+	ResticPath   string
+	KeepTypeKeys bool
 }
 
 // SSHKey struct includes both private/public keys & isDefault flag


### PR DESCRIPTION
Now I have an RSA key and an ed25519 key, RSA for personal use, and ED25519 for work. I noticed that when I switch keys by skm, it just keeps one key pair in my ssh folder, I think there should have one way to keep different types of keys coexisting in the ssh folder, there's no conflict.

In this PR I added a global flag `--keep-type-keys` and the associated environment variable is `SKM_KEEP_TYPE_KEYS`(let me know if you don't like this naming, I'm willing to change), and if you set it, `skm` will not affect other type keys.

The result like,

<img width="787" alt="image" src="https://user-images.githubusercontent.com/11025519/193799289-f45c2539-779b-46d2-bf45-50070011855f.png">

