### PR TITLE
Fix print version

### DIFF
--- a/cmd/skm/logo.go
+++ b/cmd/skm/logo.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"runtime/debug"
+	"strings"
+
 	"github.com/fatih/color"
 )
 
@@ -22,6 +25,18 @@ https://github.com/TimothyYe/skm
 `
 )
 
+// version returns the go-install module tag, else the Version var (ldflags/default).
+func version() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		v := strings.TrimPrefix(info.Main.Version, "v")
+		// accept only real release tags, skip devel/dirty/pseudo-versions
+		if v != "" && v != "(devel)" && !strings.Contains(v, "+") && !strings.HasPrefix(v, "0.0.0-") {
+			return v
+		}
+	}
+	return Version
+}
+
 func displayLogo() {
-	color.Cyan(logo, Version)
+	color.Cyan(logo, version())
 }

--- a/cmd/skm/logo.go
+++ b/cmd/skm/logo.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	// Version is the default version of SKM
-	Version = "0.8.1"
+	// Version is set via -ldflags for release builds; "dev" otherwise.
+	Version = "dev"
 	logo    = `
 
 ███████╗██╗  ██╗███╗   ███╗

--- a/cmd/skm/main.go
+++ b/cmd/skm/main.go
@@ -47,7 +47,7 @@ func main() {
 	}
 	app.Name = utils.Name
 	app.Usage = utils.Usage
-	app.Version = Version
+	app.Version = version()
 	app.Commands = initCommands()
 	if err := app.Run(os.Args); err != nil {
 		fmt.Println("Failed to run skm:", err)


### PR DESCRIPTION
Mostly self-explanatory

If skm is installed using `go install` it would use `debug.ReadBuildInfo()` to get an actual version. 
If other method - it would use `-ldflag` 

If no ldflag was set - it would use static "dev" instead of v0.8.1 as it was before.

Should fix #48 